### PR TITLE
Airport: moved Symlink instructions, added MAC spoofing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,11 +1029,12 @@ dig +short myip.opendns.com @resolver1.opendns.com
 networksetup -setairportnetwork en0 WIFI_SSID WIFI_PASSWORD
 ```
 
-#### Scan Available Access Points
-Create a symbolic link to the airport command for easy access:
+#### Create a symbolic link to the airport command for easy access:
 ```bash
 sudo ln -s /System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport /usr/local/bin/airport
 ```
+
+#### Scan Available Access Points
 Run a wireless scan:
 ```bash
 airport -s
@@ -1041,7 +1042,14 @@ airport -s
 
 #### Show Current SSID
 ```bash
-/System/Library/PrivateFrameworks/Apple80211.framework/Versions/Current/Resources/airport -I | awk '/ SSID/ {print substr($0, index($0, $2))}'
+airport -I | awk '/ SSID/ {print substr($0, index($0, $2))}'
+```
+
+#### Spoof your MAC address
+Disconnect from current WiFi network, then change MAC to any hex series.
+```bash
+sudo airport -z
+sudo ifconfig en1 ether a1:b2:c3:d4:e5:f6
 ```
 
 #### Show Local IP Address


### PR DESCRIPTION
Symlink instructions moved to it's own section, on the second line. `airport` is now used in place of the long form directory to the framework. 

MAC address spoofing instructions added.