### PR TITLE
Added Dock Autohide and Auto Hide Time Modifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -457,10 +457,18 @@ defaults write com.apple.dock scroll-to-open -bool false && \
 killall Dock
 ```
 
+#### Enable Dock Autohide
+
+``` bash
+defaults write com.apple.dock autohide -bool true && \
+killall Dock
+```
+
 #### Set Auto Show/Hide Delay
 The float number defines the show/hide delay in ms.
 ```bash
-defaults write com.apple.Dock autohide-delay -float 0 && \
+defaults write com.apple.dock autohide-time-modifier -float 0.4 && \
+defaults write com.apple.dock autohide-delay -float 0 && \
 killall Dock
 ```
 


### PR DESCRIPTION
`autohide` is a boolean and will enable autohiding your dock.
`autohide-time-modifier` is a float and will set the duration in which
your dock will pull out and in.

When doing a bootstrap installation it is useful to have the `autohide` enabled before
setting the `autohide` delay.