### PR TITLE
Remove Visual Studio Code Smiley Instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,12 +342,6 @@ defaults write com.apple.TextEdit RichText -int 0
 defaults write com.microsoft.VSCode ApplePressAndHoldEnabled -bool false
 ```
 
-#### Remove Smiley Face
-At next start the warning "Your Code installation appears to be corrupt. Please reinstall." will appear. That's fine, just click "Don't show again".
-```bash
-sed -i '' 's/\.send-feedback{display:inline-block}/\.send-feedback{display:none}/' /Applications/Visual\ Studio\ Code.app/Contents/Resources/app/out/vs/workbench/workbench.main.css
-```
-
 ## Backup
 
 ### Time Machine


### PR DESCRIPTION
Since January it is [now possible](https://github.com/Microsoft/vscode/issues/41189) to hide the twitter share icon/smiley icon using native settings in the application. Since the currently recommended method in this repository is kind of a "hack", it should not be encouraged to do it when there exists an official way. 