### PR TITLE
Add command for High Sierra USB media

### DIFF
--- a/README.md
+++ b/README.md
@@ -1570,6 +1570,9 @@ sudo sysdiagnose -f ~/Desktop/
 
 #### Create Bootable Installer
 ```bash
+# High Sierra
+sudo /Applications/Install\ macOS\ High\ Sierra.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume
+
 # Sierra
 sudo /Applications/Install\ macOS\ Sierra.app/Contents/Resources/createinstallmedia --volume /Volumes/MyVolume --applicationpath /Applications/Install\ macOS\ Sierra.app
 


### PR DESCRIPTION
Add command to create High Sierra USB, as it no longer takes the `--applicationpath` parameter.
[Source](https://support.apple.com/en-us/HT201372)