### PR TITLE
Added Update to Folder Path for macOS Mail (v5 and v6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,9 @@ set os_version to do shell script "sw_vers -productVersion"
 set mail_version to "V2"
 considering numeric strings
     if "10.10" <= os_version then set mail_version to "V3"
-    if "10.12" < os_version then set mail_version to "V4"
+    if "10.12" <= os_version then set mail_version to "V4"
+    if "10.13" <= os_version then set mail_version to "V5"
+    if "10.14" <= os_version then set mail_version to "V6"
 end considering
 
 set sizeBefore to do shell script "ls -lnah ~/Library/Mail/" & mail_version & "/MailData | grep -E 'Envelope Index$' | awk {'print $5'}"


### PR DESCRIPTION
macOS Mail is using the folder path ~/Library/Mail/V5/ in High Sierra and ~/Library/Mail/V6/ in Mojave, such that the script here needs to be updated.
The modified script has been checked with my own folder structure (macOS 10.13.6 and 10.14 beta 4), and it worked.