### PR TITLE
Add Create Temporary High-Performance Disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,11 +681,17 @@ This command applies to .iso, .img and .dmg images.
 hdiutil burn /path/to/image_file
 ```
 
-#### Create A Temporary High-Performance Disk
-The disk is backed by physical RAM and will be several times faster than an SSD. The contents of the disk cannot be recovered after it has been ejected.
-```bash
-# 500 MiB
+#### Create Temporary High-Performance Disk
+The disk is backed by physical RAM and will be several times faster than an 
+SSD. The contents of the disk cannot be recovered after it has been ejected. 
+The example below is for a 500 MiB RAM disk, adjust as needed.
+```sh
+# Up to macOS 10.14 (Mojave)
 let DISKSIZE=500*2048 && \
+diskutil erasevolume HFS+ "RAM Disk" `hdiutil attach -nomount ram://$DISKSIZE`
+
+# From macOS 10.15 (Catalina) on
+let "DISKSIZE = 500*2048" && \
 diskutil erasevolume HFS+ "RAM Disk" `hdiutil attach -nomount ram://$DISKSIZE`
 ```
 

--- a/README.md
+++ b/README.md
@@ -681,6 +681,14 @@ This command applies to .iso, .img and .dmg images.
 hdiutil burn /path/to/image_file
 ```
 
+#### Create A Temporary High-Performance Disk
+The disk is backed by physical RAM and will be several times faster than an SSD. The contents of the disk cannot be recovered after it has been ejected.
+```bash
+# 500 MiB
+let DISKSIZE=500*2048 && \
+diskutil erasevolume HFS+ "RAM Disk" `hdiutil attach -nomount ram://$DISKSIZE`
+```
+
 #### Disable Disk Image Verification
 ```bash
 defaults write com.apple.frameworks.diskimages skip-verify -bool true && \


### PR DESCRIPTION
Have unfortunately not been able to test this with macOS 10.12 or later.  Works in 10.11 and as far back as I can remember.