### PR TITLE
Remove unsupported flags from brew install macvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -433,7 +433,7 @@ sudo tmutil verifychecksums /path/to/backup
 #### Compile Sane Vim
 Compiling MacVim via Homebrew with all bells and whistles, including overriding system Vim.
 ```bash
-brew install macvim --HEAD --with-cscope --with-lua --with-override-system-vim --with-luajit --with-python
+brew install macvim --HEAD
 ```
 
 #### Neovim


### PR DESCRIPTION
Homebrew does not support the extra flags anymore and overrides system vi by default.