### PR TITLE
Add Summary of Network Information

### DIFF
--- a/README.md
+++ b/README.md
@@ -1337,8 +1337,9 @@ Alternative that works on all networks.
 ```bash
 curl -s https://api.ipify.org && echo
 ```
-#### Show Summary of Network Information
-This displays all your network interface information, both for IPv4 and IPv6.
+
+#### Show Network Interface Information
+Undocumented flag of the `scutil` command.
 ```bash
 scutil --nwi
 ```

--- a/README.md
+++ b/README.md
@@ -1336,7 +1336,12 @@ dig +short myip.opendns.com @resolver1.opendns.com
 Alternative that works on all networks.
 ```bash
 curl -s https://api.ipify.org && echo
-````
+```
+#### Show Summary of Network Information
+This displays all your network interface information, both for IPv4 and IPv6.
+```bash
+scutil --nwi
+```
 
 ### TFTP
 


### PR DESCRIPTION
This switch seems to be undocumented in the man page, it gives a summary of all network interfaces. It shows info like nic bsd name, current ip address for ipv4 and ipv6