### PR TITLE
Add mpm, a unifying CLI to all package managers on your system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1596,6 +1596,9 @@ networksetup -setairportpower en0 on
   popular choice.
 - [MacPorts](https://www.macports.org) - Compile, install and upgrade either 
   command-line, X11 or Aqua based open-source software.
+- [Meta Package Manager](https://github.com/kdeldycke/meta-package-manager) -
+  Manage several package managers from one unified CLI. Supports Homebrew,
+  Cask, `mas`, `npm`, `pip` and others.
 
 ### Homebrew
 


### PR DESCRIPTION
Meta Package Manager is a CLI that detects all package managers installed on your system and provides a unifying interface. That way you can list all packages installed on your system, and upgrade to their latest version, all with a single command.

It was originally developed on macOS and as such supports Homebrew, Cask and Mac App Store.