### PR TITLE
remove leading `*` from `.DS_Store`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,7 +1769,7 @@ srm -rf /path/to/complete/destruction
 
 #### Recursively Delete .DS_Store Files
 ```sh
-find . -type f -name '*.DS_Store' -ls -delete
+find . -type f -name '.DS_Store' -ls -delete
 ```
 
 ### Locate


### PR DESCRIPTION
`.DS_Store` is an entire filename (see also https://github.com/github/gitignore/commit/2bb963b16a1957c865335e53537036c2e97399b5). The command
```sh
find . -type f -name '*.DS_Store' -ls -delete
```
deletes _all_ files with a `.DS_Store` extension, including `don’t_delete_me.DS_Store`