### PR TITLE
Update Optimize Mail section to include Catalina

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ considering numeric strings
     if "10.12" <= os_version then set mail_version to "V4"
     if "10.13" <= os_version then set mail_version to "V5"
     if "10.14" <= os_version then set mail_version to "V6"
+    if "10.15" <= os_version then set mail_version to "V7"
 end considering
 
 set sizeBefore to do shell script "ls -lnah ~/Library/Mail/" & mail_version & "/MailData | grep -E 'Envelope Index$' | awk {'print $5'}"


### PR DESCRIPTION
## Motivation
Previously, the section for optimizing mail ([README.md §Vacuum Mail Index](https://github.com/herrbischoff/awesome-macos-command-line/blob/master/README.md#vacuum-mail-index)) only compatible for up to Mojave.

## Changes
Added macOS `10.15` Catalina and its Mail version of V7.